### PR TITLE
Reduce linter warnings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Users, Target, FileText, Megaphone, UserPlus, Shield, BarChart3, Settings } from 'lucide-react';
+import { Users, Target, FileText, Megaphone, UserPlus, Shield, BarChart3 } from 'lucide-react';
 import { AppProvider } from './contexts/AppContext';
 import RoleSelector from './components/RoleSelector';
 import DashboardLayout from './components/DashboardLayout';
@@ -16,7 +16,7 @@ import DataAnalyticsDashboard from './components/dashboards/DataAnalyticsDashboa
 export interface Role {
   id: string;
   name: string;
-  icon: React.ComponentType<any>;
+  icon: React.ComponentType<unknown>;
   color: string;
   description: string;
 }

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LogOut, User, CheckSquare, Settings, Moon, Sun, Menu, X } from 'lucide-react';
+import { LogOut, User, CheckSquare, Moon, Sun, Menu, X } from 'lucide-react';
 import { Role } from '../App';
 import { useAppContext } from '../contexts/AppContext';
 import NotificationCenter from './shared/NotificationCenter';

--- a/src/components/TaskManagement/TaskBoard.tsx
+++ b/src/components/TaskManagement/TaskBoard.tsx
@@ -82,7 +82,7 @@ const TaskBoard: React.FC<TaskBoardProps> = ({ roles, currentRole }) => {
   const [viewMode, setViewMode] = useState<'kanban' | 'list'>('kanban');
   const [showFilters, setShowFilters] = useState(false);
 
-  const columns: { status: TaskStatus; title: string; icon: React.ComponentType<any>; color: string }[] = [
+  const columns: { status: TaskStatus; title: string; icon: React.ComponentType<unknown>; color: string }[] = [
     { status: 'todo', title: 'To Do', icon: Clock, color: 'text-gray-600' },
     { status: 'in-progress', title: 'In Progress', icon: AlertCircle, color: 'text-blue-600' },
     { status: 'done', title: 'Done', icon: CheckCircle, color: 'text-green-600' }

--- a/src/components/dashboards/ChairDashboard.tsx
+++ b/src/components/dashboards/ChairDashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Users, Target, TrendingUp, AlertCircle, CheckCircle, Calendar, Plus, Filter, Download, Bell, ArrowUp, ArrowDown, Eye, Edit, Trash2, MoreVertical, X, FileText, Clock, Send, UserPlus, Settings } from 'lucide-react';
+import React, { useState } from 'react';
+import { Users, Target, TrendingUp, AlertCircle, CheckCircle, Calendar, Plus, Filter, Download, Bell, ArrowUp, ArrowDown, Eye, Edit, MoreVertical, X, FileText } from 'lucide-react';
 
 // Modal Components
 const NECReportModal: React.FC<{ isOpen: boolean; onClose: () => void; onGenerate: (data: any) => void }> = ({ isOpen, onClose, onGenerate }) => {

--- a/src/components/dashboards/ChapterDevDashboard.tsx
+++ b/src/components/dashboards/ChapterDevDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Shield, Users, Calendar, BookOpen, Award, Clock, Archive, Video } from 'lucide-react';
+import { Shield, Users, Calendar, BookOpen, Award, Archive, Video } from 'lucide-react';
 import GoogleDriveIntegration from '../shared/GoogleDriveIntegration';
 import GoogleCalendarIntegration from '../shared/GoogleCalendarIntegration';
 

--- a/src/components/dashboards/ComplianceDashboard.tsx
+++ b/src/components/dashboards/ComplianceDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Shield, AlertTriangle, CheckCircle, FileText, Calendar, Users, Plus, Edit, X, Save, Eye, Download, Upload, TrendingUp, Clock } from 'lucide-react';
+import { Shield, AlertTriangle, CheckCircle, FileText, Calendar, Plus, X, TrendingUp } from 'lucide-react';
 
 const ComplianceDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState('risk-assessment');

--- a/src/components/dashboards/DataAnalyticsDashboard.tsx
+++ b/src/components/dashboards/DataAnalyticsDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { BarChart3, TrendingUp, Database, Download, Filter, RefreshCw, Plus, Eye, X, Save, Upload, Search, Calendar } from 'lucide-react';
+import { BarChart3, TrendingUp, Database, Download, Filter, RefreshCw, Plus, Eye, X, Search } from 'lucide-react';
 
 const DataAnalyticsDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState('kpi-analytics');

--- a/src/components/dashboards/MarketingDashboard.tsx
+++ b/src/components/dashboards/MarketingDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Megaphone, Palette, Image, Download, Plus, Eye, Edit, X, Save, Upload, Share2, Trash2, Calendar, Archive } from 'lucide-react';
+import { Megaphone, Palette, Image, Download, Plus, Edit, X, Calendar, Archive } from 'lucide-react';
 import GoogleDriveIntegration from '../shared/GoogleDriveIntegration';
 import GoogleCalendarIntegration from '../shared/GoogleCalendarIntegration';
 

--- a/src/components/dashboards/RecruitmentDashboard.tsx
+++ b/src/components/dashboards/RecruitmentDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { UserPlus, Phone, Mail, MapPin, Calendar, Filter, Plus, Search, X, Save, Edit, Trash2, Eye, Archive } from 'lucide-react';
+import { UserPlus, Phone, Mail, MapPin, Calendar, Plus, Search, X, Trash2, Eye, Archive } from 'lucide-react';
 import GoogleDriveIntegration from '../shared/GoogleDriveIntegration';
 import GoogleCalendarIntegration from '../shared/GoogleCalendarIntegration';
 

--- a/src/components/dashboards/SecretaryDashboard.tsx
+++ b/src/components/dashboards/SecretaryDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { FileText, Calendar, Archive, Download, Plus, Search, Filter, X, Save, Edit, Trash2, Eye, Upload } from 'lucide-react';
+import { FileText, Calendar, Archive, Download, Plus, Search, X, Save, Trash2, Eye } from 'lucide-react';
 import GoogleDriveIntegration from '../shared/GoogleDriveIntegration';
 import GoogleCalendarIntegration from '../shared/GoogleCalendarIntegration';
 

--- a/src/components/dashboards/ViceChairDashboard.tsx
+++ b/src/components/dashboards/ViceChairDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Target, TrendingUp, AlertTriangle, Users, Activity, Calendar, Plus, Edit, Download, RefreshCw, X, Save, Trash2 } from 'lucide-react';
+import { Target, TrendingUp, AlertTriangle, Users, Activity, Plus, Edit, Download, RefreshCw, X, Trash2 } from 'lucide-react';
 
 const ViceChairDashboard: React.FC = () => {
   const [activeTab, setActiveTab] = useState('kpi');

--- a/src/components/shared/GlobalSearch.tsx
+++ b/src/components/shared/GlobalSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Search, X, FileText, Users, AlertTriangle, Target, Calendar } from 'lucide-react';
+import { Search, FileText, Users, AlertTriangle, Target, Calendar } from 'lucide-react';
 import { useAppContext } from '../../contexts/AppContext';
 
 interface SearchResult {
@@ -9,7 +9,7 @@ interface SearchResult {
   type: 'task' | 'contact' | 'risk' | 'kpi' | 'document' | 'meeting';
   category: string;
   url?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 const GlobalSearch: React.FC = () => {
@@ -17,7 +17,7 @@ const GlobalSearch: React.FC = () => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const { globalTasks, sharedData } = useAppContext();
+  const { globalTasks } = useAppContext();
 
   // Mock search data - in a real app, this would come from APIs
   const searchableData: SearchResult[] = [

--- a/src/components/shared/GoogleCalendarIntegration.tsx
+++ b/src/components/shared/GoogleCalendarIntegration.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Calendar, Clock, Users, MapPin, Video, Plus, Edit, Trash2, ExternalLink } from 'lucide-react';
+import { Calendar, Clock, Users, MapPin, Video, Plus, ExternalLink } from 'lucide-react';
 import { googleCalendarService, CalendarEvent } from '../../services/googleCalendarService';
 import { useAppContext } from '../../contexts/AppContext';
 
@@ -65,7 +65,8 @@ const GoogleCalendarIntegration: React.FC<GoogleCalendarIntegrationProps> = ({
       });
       await loadEvents();
       setShowCreateModal(false);
-    } catch (error) {
+    } catch (_error) {
+      void _error;
       addNotification({
         title: 'Failed to Create Event',
         message: 'Could not create the calendar event',

--- a/src/components/shared/GoogleDriveIntegration.tsx
+++ b/src/components/shared/GoogleDriveIntegration.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Upload, Download, Share2, Trash2, Eye, FolderPlus, Search, ExternalLink, FileText, Image, Video, Archive } from 'lucide-react';
+import { Upload, Download, Share2, Trash2, Eye, Search, ExternalLink, FileText, Image, Video, Archive } from 'lucide-react';
 import { googleDriveService, GoogleDriveFile } from '../../services/googleDriveService';
 import { useAppContext } from '../../contexts/AppContext';
 
@@ -22,7 +22,6 @@ const GoogleDriveIntegration: React.FC<GoogleDriveIntegrationProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [isUploading, setIsUploading] = useState(false);
-  const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const { addNotification } = useAppContext();
 
   useEffect(() => {
@@ -104,7 +103,8 @@ const GoogleDriveIntegration: React.FC<GoogleDriveIntegrationProps> = ({
         priority: 'low',
         category: 'system'
       });
-    } catch (error) {
+    } catch (_error) {
+      void _error;
       addNotification({
         title: 'Sharing Failed',
         message: 'Failed to share the file',
@@ -128,7 +128,8 @@ const GoogleDriveIntegration: React.FC<GoogleDriveIntegrationProps> = ({
         category: 'system'
       });
       await loadFiles();
-    } catch (error) {
+    } catch (_error) {
+      void _error;
       addNotification({
         title: 'Delete Failed',
         message: 'Failed to delete the file',

--- a/src/components/shared/NotificationCenter.tsx
+++ b/src/components/shared/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Bell, X, Check, AlertCircle, Info, CheckCircle, AlertTriangle } from 'lucide-react';
+import { Bell, X, AlertCircle, Info, CheckCircle, AlertTriangle } from 'lucide-react';
 import { useAppContext } from '../../contexts/AppContext';
 import { Notification } from '../../types/Notification';
 

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { User, UserSession } from '../types/User';
 import { Notification } from '../types/Notification';
 import { Task } from '../types/Task';
-import { Role } from '../App';
 
 interface AppContextType {
   // User & Authentication
@@ -26,8 +25,8 @@ interface AppContextType {
   setTheme: (theme: 'light' | 'dark') => void;
   
   // Cross-dashboard data sharing
-  sharedData: Record<string, any>;
-  updateSharedData: (key: string, value: any) => void;
+  sharedData: Record<string, unknown>;
+  updateSharedData: (key: string, value: unknown) => void;
   
   // Real-time updates
   lastDataSync: string;
@@ -54,7 +53,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [globalTasks, setGlobalTasks] = useState<Task[]>([]);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
-  const [sharedData, setSharedData] = useState<Record<string, any>>({});
+  const [sharedData, setSharedData] = useState<Record<string, unknown>>({});
   const [lastDataSync, setLastDataSync] = useState<string>(new Date().toISOString());
 
   // Initialize user from session
@@ -117,7 +116,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
   const unreadCount = notifications.filter(n => !n.read).length;
 
-  const updateSharedData = (key: string, value: any) => {
+  const updateSharedData = (key: string, value: unknown) => {
     setSharedData(prev => ({ ...prev, [key]: value }));
   };
 

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
   const [storedValue, setStoredValue] = useState<T>(() => {

--- a/src/services/googleCalendarService.ts
+++ b/src/services/googleCalendarService.ts
@@ -84,6 +84,9 @@ class GoogleCalendarService {
   }
 
   async getEvents(calendarId: string = 'primary', timeMin?: string, timeMax?: string): Promise<CalendarEvent[]> {
+    void calendarId;
+    void timeMin;
+    void timeMax;
     await new Promise(resolve => setTimeout(resolve, 400));
     
     return [
@@ -154,6 +157,7 @@ class GoogleCalendarService {
   }
 
   async createEvent(calendarId: string, event: Partial<CalendarEvent>): Promise<CalendarEvent> {
+    void calendarId;
     await new Promise(resolve => setTimeout(resolve, 600));
     
     const newEvent: CalendarEvent = {
@@ -192,6 +196,8 @@ class GoogleCalendarService {
   }
 
   async deleteEvent(calendarId: string, eventId: string): Promise<boolean> {
+    void calendarId;
+    void eventId;
     await new Promise(resolve => setTimeout(resolve, 300));
     return true;
   }

--- a/src/services/googleDriveService.ts
+++ b/src/services/googleDriveService.ts
@@ -8,7 +8,7 @@ interface GoogleDriveFile {
   webContentLink: string;
   parents: string[];
   shared: boolean;
-  permissions: any[];
+  permissions: unknown[];
 }
 
 interface GoogleDriveFolder {
@@ -35,7 +35,8 @@ class GoogleDriveService {
     }
   }
 
-  async createFolder(name: string, parentId?: string): Promise<GoogleDriveFolder> {
+  async createFolder(name: string, _parentId?: string): Promise<GoogleDriveFolder> {
+    void _parentId;
     // Simulate API call
     await new Promise(resolve => setTimeout(resolve, 500));
     
@@ -65,7 +66,8 @@ class GoogleDriveService {
     };
   }
 
-  async getFiles(folderId?: string): Promise<GoogleDriveFile[]> {
+  async getFiles(_folderId?: string): Promise<GoogleDriveFile[]> {
+    void _folderId;
     // Simulate getting files
     await new Promise(resolve => setTimeout(resolve, 300));
     
@@ -109,13 +111,17 @@ class GoogleDriveService {
     ];
   }
 
-  async shareFile(fileId: string, email: string, role: 'reader' | 'writer' | 'commenter' = 'reader'): Promise<boolean> {
+  async shareFile(_fileId: string, _email: string, _role: 'reader' | 'writer' | 'commenter' = 'reader'): Promise<boolean> {
+    void _fileId;
+    void _email;
+    void _role;
     // Simulate sharing
     await new Promise(resolve => setTimeout(resolve, 500));
     return true;
   }
 
-  async deleteFile(fileId: string): Promise<boolean> {
+  async deleteFile(_fileId: string): Promise<boolean> {
+    void _fileId;
     // Simulate deletion
     await new Promise(resolve => setTimeout(resolve, 300));
     return true;

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,4 +1,4 @@
-export const exportToCSV = (data: any[], filename: string): void => {
+export const exportToCSV = (data: Record<string, unknown>[], filename: string): void => {
   if (data.length === 0) return;
 
   const headers = Object.keys(data[0]);
@@ -30,7 +30,7 @@ export const exportToCSV = (data: any[], filename: string): void => {
   }
 };
 
-export const exportToJSON = (data: any, filename: string): void => {
+export const exportToJSON = (data: unknown, filename: string): void => {
   const jsonContent = JSON.stringify(data, null, 2);
   const blob = new Blob([jsonContent], { type: 'application/json;charset=utf-8;' });
   const link = document.createElement('a');
@@ -46,7 +46,7 @@ export const exportToJSON = (data: any, filename: string): void => {
   }
 };
 
-export const generateReport = (data: any, title: string): string => {
+export const generateReport = (data: unknown, title: string): string => {
   const timestamp = new Date().toISOString();
   
   return `


### PR DESCRIPTION
## Summary
- clean up unused imports on dashboard components
- linter errors reduced

## Testing
- `npm run lint` *(fails: 68 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6842d92d1b1c832b876b0946c9226ffa