### PR TITLE
Integrate task board with FastAPI

### DIFF
--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -1,0 +1,46 @@
+import { Task } from '../types/Task';
+
+class TaskService {
+  private baseUrl: string = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+  async list(): Promise<Task[]> {
+    const res = await fetch(`${this.baseUrl}/tasks/`);
+    if (!res.ok) {
+      throw new Error('Failed to fetch tasks');
+    }
+    return res.json();
+  }
+
+  async create(task: Omit<Task, 'id' | 'createdAt'>): Promise<Task> {
+    const res = await fetch(`${this.baseUrl}/tasks/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(task),
+    });
+    if (!res.ok) {
+      throw new Error('Failed to create task');
+    }
+    return res.json();
+  }
+
+  async update(id: string, task: Partial<Omit<Task, 'id' | 'createdAt' | 'createdBy'>>): Promise<Task> {
+    const res = await fetch(`${this.baseUrl}/tasks/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(task),
+    });
+    if (!res.ok) {
+      throw new Error('Failed to update task');
+    }
+    return res.json();
+  }
+
+  async delete(id: string): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/tasks/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      throw new Error('Failed to delete task');
+    }
+  }
+}
+
+export const taskService = new TaskService();


### PR DESCRIPTION
## Summary
- add Task service for API interaction
- load tasks from the FastAPI backend
- use API for create/update/delete in the task board
- sync task state with global context for search

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3ace138832b9f03feff3c4610cb