### PR TITLE
Integrate backend auth with frontend

### DIFF
--- a/src/components/AuthenticationModal.tsx
+++ b/src/components/AuthenticationModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Lock, User, Eye, EyeOff } from 'lucide-react';
 import { Role } from '../App';
+import { useAppContext } from '../contexts/AppContext';
 
 interface AuthenticationModalProps {
   selectedRole: Role;
@@ -14,16 +15,17 @@ const AuthenticationModal: React.FC<AuthenticationModalProps> = ({ selectedRole,
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  // Demo passwords for each role (in production, this would be handled by a secure backend)
-  const rolePasswords: { [key: string]: string } = {
-    'chair': 'chair2024',
-    'vice-chair': 'vicechair2024',
-    'secretary': 'secretary2024',
-    'marketing': 'marketing2024',
-    'recruitment': 'recruitment2024',
-    'chapter-dev': 'chapterdev2024',
-    'compliance': 'compliance2024',
-    'data-analytics': 'analytics2024'
+  const { login } = useAppContext();
+
+  const roleEmails: { [key: string]: string } = {
+    'chair': 'chair@khk.org',
+    'vice-chair': 'vice-chair@khk.org',
+    'secretary': 'secretary@khk.org',
+    'marketing': 'marketing@khk.org',
+    'recruitment': 'recruitment@khk.org',
+    'chapter-dev': 'chapter-dev@khk.org',
+    'compliance': 'compliance@khk.org',
+    'data-analytics': 'analytics@khk.org'
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -31,16 +33,13 @@ const AuthenticationModal: React.FC<AuthenticationModalProps> = ({ selectedRole,
     setIsLoading(true);
     setError('');
 
-    // Simulate authentication delay
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    if (password === rolePasswords[selectedRole.id]) {
+    const email = roleEmails[selectedRole.id] ?? `${selectedRole.id}@khk.org`;
+    const success = await login(email, password);
+    if (success) {
       onAuthenticate(true);
     } else {
-      setError('Invalid password. Please try again.');
-      setPassword('');
+      setError('Invalid credentials');
     }
-    
     setIsLoading(false);
   };
 
@@ -132,10 +131,6 @@ const AuthenticationModal: React.FC<AuthenticationModalProps> = ({ selectedRole,
             )}
           </button>
 
-          <div className="mt-4 p-3 bg-gray-50 rounded-lg">
-            <p className="text-xs font-medium text-gray-600 mb-2">Demo Credentials:</p>
-            <p className="text-xs text-gray-500">Password: {rolePasswords[selectedRole.id]}</p>
-          </div>
         </form>
       </div>
     </div>

--- a/src/components/RoleSelector.tsx
+++ b/src/components/RoleSelector.tsx
@@ -122,25 +122,6 @@ const RoleSelector: React.FC<RoleSelectorProps> = ({ roles, onRoleSelect }) => {
           </div>
         </div>
 
-        {/* Demo Information - Mobile Optimized */}
-        <div className="max-w-2xl mx-auto mt-6 sm:mt-8 px-4">
-          <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4 sm:p-6">
-            <h3 className="font-semibold text-yellow-900 mb-2 sm:mb-3 text-sm sm:text-base">Demo Access Information</h3>
-            <p className="text-xs sm:text-sm text-yellow-800 mb-2 sm:mb-3">
-              This is a demonstration platform. Each role has a demo password for testing purposes:
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 sm:gap-2 text-xs text-yellow-700">
-              <div>• Chair: chair2024</div>
-              <div>• Vice-Chair: vicechair2024</div>
-              <div>• Secretary: secretary2024</div>
-              <div>• Marketing: marketing2024</div>
-              <div>• Recruitment: recruitment2024</div>
-              <div>• Chapter Dev: chapterdev2024</div>
-              <div>• Compliance: compliance2024</div>
-              <div>• Data Analytics: analytics2024</div>
-            </div>
-          </div>
-        </div>
       </div>
 
       {/* Authentication Modal */}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,38 @@
+import { User, UserSession } from '../types/User';
+
+class AuthService {
+  private baseUrl: string = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+  private handleResponse = async (res: Response) => {
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Request failed');
+    }
+    return res.json();
+  };
+
+  async login(email: string, password: string): Promise<UserSession> {
+    const body = new URLSearchParams({ username: email, password });
+    const res = await fetch(`${this.baseUrl}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body
+    });
+    const data = await this.handleResponse(res);
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    return {
+      user: data.user as User,
+      token: data.access_token as string,
+      expiresAt
+    };
+  }
+
+  async currentUser(token: string): Promise<User> {
+    const res = await fetch(`${this.baseUrl}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    return this.handleResponse(res);
+  }
+}
+
+export const authService = new AuthService();

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,9 +2,24 @@ import { Task } from '../types/Task';
 
 class TaskService {
   private baseUrl: string = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+  private authToken: string | null = null;
+
+  setAuthToken(token: string | null) {
+    this.authToken = token;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.authToken) {
+      headers['Authorization'] = `Bearer ${this.authToken}`;
+    }
+    return headers;
+  }
 
   async list(): Promise<Task[]> {
-    const res = await fetch(`${this.baseUrl}/tasks/`);
+    const res = await fetch(`${this.baseUrl}/tasks/`, {
+      headers: this.buildHeaders(),
+    });
     if (!res.ok) {
       throw new Error('Failed to fetch tasks');
     }
@@ -14,7 +29,7 @@ class TaskService {
   async create(task: Omit<Task, 'id' | 'createdAt'>): Promise<Task> {
     const res = await fetch(`${this.baseUrl}/tasks/`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.buildHeaders(),
       body: JSON.stringify(task),
     });
     if (!res.ok) {
@@ -26,7 +41,7 @@ class TaskService {
   async update(id: string, task: Partial<Omit<Task, 'id' | 'createdAt' | 'createdBy'>>): Promise<Task> {
     const res = await fetch(`${this.baseUrl}/tasks/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.buildHeaders(),
       body: JSON.stringify(task),
     });
     if (!res.ok) {
@@ -36,7 +51,10 @@ class TaskService {
   }
 
   async delete(id: string): Promise<void> {
-    const res = await fetch(`${this.baseUrl}/tasks/${id}`, { method: 'DELETE' });
+    const res = await fetch(`${this.baseUrl}/tasks/${id}`, {
+      method: 'DELETE',
+      headers: this.buildHeaders(),
+    });
     if (!res.ok) {
       throw new Error('Failed to delete task');
     }


### PR DESCRIPTION
## Summary
- add `authService` for calling the FastAPI auth routes
- allow `taskService` to send Authorization headers
- store session details in `AppContext` and expose login/logout helpers
- wire up authentication modal with backend login
- remove old demo password text from role selector

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842e6deded4832bba8d81bbdade4b9b