### PR TITLE
Add chair password initializer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ frontend.  During development you normally run them separately.
    ```bash
    python -m app.create_db
    ```
-4. **Run the API** in autoreload mode on port 8000:
+4. **Set the chair password**
+   ```bash
+   CHAIR_PASSWORD=my-secret python -m app.set_chair_password
+   ```
+5. **Run the API** in autoreload mode on port 8000:
    ```bash
    uvicorn app.main:app --reload --port 8000
    ```

--- a/backend/app/set_chair_password.py
+++ b/backend/app/set_chair_password.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+from sqlalchemy.future import select
+
+from .db import AsyncSessionLocal
+from .models.user import User
+from .routers.auth import get_password_hash
+
+CHAIR_EMAIL = os.getenv("CHAIR_EMAIL", "chair@khk.org")
+INITIAL_PASSWORD = os.getenv("CHAIR_PASSWORD")
+
+async def main() -> None:
+    if not INITIAL_PASSWORD:
+        raise SystemExit("CHAIR_PASSWORD environment variable not set")
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(User).where(User.role == "chair"))
+        chair = result.scalars().first()
+
+        if chair:
+            if chair.hashed_password:
+                print("Chair already has a password set")
+                return
+            chair.hashed_password = get_password_hash(INITIAL_PASSWORD)
+            await session.commit()
+            print("Chair password initialized")
+        else:
+            chair = User(
+                name="Chair",
+                email=CHAIR_EMAIL,
+                hashed_password=get_password_hash(INITIAL_PASSWORD),
+                role="chair",
+            )
+            session.add(chair)
+            await session.commit()
+            print("Chair user created with password")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- create a helper to bootstrap the chair user's password
- document the new step in the README

## Testing
- `npm run lint` *(fails: 64 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6842f0b291f4832b9ea8e25988cfcf3c