### PR TITLE
Initialize chair password automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ frontend.  During development you normally run them separately.
    cp .env.sample .env
    # edit .env and set DATABASE_URL and SECRET_KEY
    ```
-3. **Initialize the database**
+3. **Configure the chair account** – add a password to `.env`:
    ```bash
-   python -m app.create_db
+   echo "CHAIR_PASSWORD=my-secret" >> .env
+   # optionally set CHAIR_EMAIL=user@example.com
    ```
-4. **Set the chair password**
-   ```bash
-   CHAIR_PASSWORD=my-secret python -m app.set_chair_password
-   ```
-5. **Run the API** in autoreload mode on port 8000:
+   The database tables and chair user will be created automatically on first
+   launch.
+4. **Run the API** in autoreload mode on port 8000:
    ```bash
    uvicorn app.main:app --reload --port 8000
    ```

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,3 +1,5 @@
 # Example Neon database URL
 DATABASE_URL=postgresql+asyncpg://user:password@host/dbname?sslmode=require
 SECRET_KEY=super-secret-key
+# Initial chair account password
+CHAIR_PASSWORD=change-me

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,17 +3,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .db import AsyncSessionLocal
 from .routers import tasks, auth, users, contacts
+from .startup import init_db_and_chair
 
 app = FastAPI(title="KHK Expansion API")
+
 
 async def get_db() -> AsyncSession:
     async with AsyncSessionLocal() as session:
         yield session
 
+
+@app.on_event("startup")
+async def startup() -> None:
+    """Initialize the database and chair account on application start."""
+    await init_db_and_chair()
+
+
 app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(tasks.router)
 app.include_router(contacts.router)
+
 
 @app.get("/health")
 async def health():

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -1,0 +1,39 @@
+import os
+from sqlalchemy.future import select
+
+from .db import engine, Base, AsyncSessionLocal
+from .models.user import User
+from .routers.auth import get_password_hash
+
+
+async def init_db_and_chair() -> None:
+    """Create database tables and ensure a chair user exists."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    initial_password = os.getenv("CHAIR_PASSWORD")
+    chair_email = os.getenv("CHAIR_EMAIL", "chair@khk.org")
+
+    if not initial_password:
+        print("CHAIR_PASSWORD not set; skipping chair initialization")
+        return
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(User).where(User.role == "chair"))
+        chair = result.scalars().first()
+
+        if chair:
+            if not chair.hashed_password:
+                chair.hashed_password = get_password_hash(initial_password)
+                await session.commit()
+                print("Chair password initialized")
+        else:
+            chair = User(
+                name="Chair",
+                email=chair_email,
+                hashed_password=get_password_hash(initial_password),
+                role="chair",
+            )
+            session.add(chair)
+            await session.commit()
+            print("Chair user created with password")


### PR DESCRIPTION
## Summary
- add startup hook to create database tables and chair account on boot
- document CHAIR_PASSWORD in `.env.sample`
- simplify backend setup instructions in README

## Testing
- `black backend/app/main.py backend/app/startup.py`
- `python -m app.startup` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6843061e8114832b947f77d9eaa845bc