### PR TITLE
Add module-level docstrings to backend

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,3 +1,11 @@
+"""Database configuration for the FastAPI backend.
+
+This module exposes the SQLAlchemy asynchronous engine, session maker,
+and declarative base used by the application. The ``AsyncSessionLocal``
+context manager yields database sessions and ``Base`` is used for model
+declarations in ``backend/app/models``.
+"""
+
 import os
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,1 +1,3 @@
+"""Expose all API routers for application setup."""
+
 from . import tasks, auth, users, contacts

--- a/backend/app/routers/contacts.py
+++ b/backend/app/routers/contacts.py
@@ -1,3 +1,10 @@
+"""CRUD operations for ``UniversityContact`` records.
+
+This router provides endpoints to list, create, update and delete university
+contacts stored in the database. Each endpoint relies on an asynchronous SQL
+Alchemy session obtained from ``AsyncSessionLocal``.
+"""
+
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -14,22 +21,30 @@ from ..schemas.contact import (
 
 router = APIRouter(prefix="/contacts", tags=["contacts"])
 
+
 async def get_db() -> AsyncSession:
     async with AsyncSessionLocal() as session:
         yield session
+
 
 @router.get("/", response_model=List[UniversityContactResponse])
 async def list_contacts(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(UniversityContact))
     return result.scalars().all()
 
-@router.post("/", response_model=UniversityContactResponse, status_code=status.HTTP_201_CREATED)
-async def create_contact(contact: UniversityContactCreate, db: AsyncSession = Depends(get_db)):
+
+@router.post(
+    "/", response_model=UniversityContactResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_contact(
+    contact: UniversityContactCreate, db: AsyncSession = Depends(get_db)
+):
     db_contact = UniversityContact(**contact.dict(by_alias=False))
     db.add(db_contact)
     await db.commit()
     await db.refresh(db_contact)
     return db_contact
+
 
 @router.get("/{contact_id}", response_model=UniversityContactResponse)
 async def get_contact(contact_id: int, db: AsyncSession = Depends(get_db)):
@@ -38,8 +53,13 @@ async def get_contact(contact_id: int, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Contact not found")
     return contact
 
+
 @router.put("/{contact_id}", response_model=UniversityContactResponse)
-async def update_contact(contact_id: int, contact_update: UniversityContactUpdate, db: AsyncSession = Depends(get_db)):
+async def update_contact(
+    contact_id: int,
+    contact_update: UniversityContactUpdate,
+    db: AsyncSession = Depends(get_db),
+):
     contact = await db.get(UniversityContact, contact_id)
     if not contact:
         raise HTTPException(status_code=404, detail="Contact not found")
@@ -48,6 +68,7 @@ async def update_contact(contact_id: int, contact_update: UniversityContactUpdat
     await db.commit()
     await db.refresh(contact)
     return contact
+
 
 @router.delete("/{contact_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_contact(contact_id: int, db: AsyncSession = Depends(get_db)):

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,3 +1,10 @@
+"""Task management endpoints.
+
+The routes defined here allow clients to create, list, update and delete
+``Task`` records. All operations use asynchronous database sessions and return
+Pydantic response models for serialization.
+"""
+
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,15 +16,18 @@ from ..schemas.task import TaskCreate, TaskResponse, TaskUpdate
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
+
 async def get_db() -> AsyncSession:
     async with AsyncSessionLocal() as session:
         yield session
+
 
 @router.get("/", response_model=List[TaskResponse])
 async def list_tasks(db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(Task))
     tasks = result.scalars().all()
     return tasks
+
 
 @router.post("/", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
 async def create_task(task: TaskCreate, db: AsyncSession = Depends(get_db)):
@@ -27,6 +37,7 @@ async def create_task(task: TaskCreate, db: AsyncSession = Depends(get_db)):
     await db.refresh(db_task)
     return db_task
 
+
 @router.get("/{task_id}", response_model=TaskResponse)
 async def get_task(task_id: int, db: AsyncSession = Depends(get_db)):
     task = await db.get(Task, task_id)
@@ -34,8 +45,11 @@ async def get_task(task_id: int, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Task not found")
     return task
 
+
 @router.put("/{task_id}", response_model=TaskResponse)
-async def update_task(task_id: int, task_update: TaskUpdate, db: AsyncSession = Depends(get_db)):
+async def update_task(
+    task_id: int, task_update: TaskUpdate, db: AsyncSession = Depends(get_db)
+):
     task = await db.get(Task, task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -44,6 +58,7 @@ async def update_task(task_id: int, task_update: TaskUpdate, db: AsyncSession = 
     await db.commit()
     await db.refresh(task)
     return task
+
 
 @router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_task(task_id: int, db: AsyncSession = Depends(get_db)):

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,3 +1,10 @@
+"""User registration and profile endpoints.
+
+This router exposes a registration endpoint for new users and an endpoint to
+retrieve the currently authenticated user using dependencies from the auth
+router.
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -9,9 +16,11 @@ from ..schemas.user import UserCreate, UserResponse
 
 router = APIRouter(prefix="/users", tags=["users"])
 
+
 async def get_db() -> AsyncSession:
     async with AsyncSessionLocal() as session:
         yield session
+
 
 @router.post("/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def register_user(user: UserCreate, db: AsyncSession = Depends(get_db)):
@@ -30,6 +39,7 @@ async def register_user(user: UserCreate, db: AsyncSession = Depends(get_db)):
     await db.commit()
     await db.refresh(db_user)
     return db_user
+
 
 @router.get("/me", response_model=UserResponse)
 async def read_current_user(current_user: User = Depends(get_current_user)):

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience imports for schema classes."""
+
 from .task import TaskCreate, TaskUpdate, TaskResponse
 from .user import UserCreate, UserResponse
 from .contact import (

--- a/backend/app/schemas/contact.py
+++ b/backend/app/schemas/contact.py
@@ -1,10 +1,14 @@
+"""Pydantic models for university contacts."""
+
 from datetime import date
 from typing import Optional
 from pydantic import BaseModel, Field
 
+
 class ConfigBase:
     from_attributes = True
     populate_by_name = True
+
 
 class UniversityContactBase(BaseModel):
     university: str
@@ -23,8 +27,10 @@ class UniversityContactBase(BaseModel):
     class Config(ConfigBase):
         pass
 
+
 class UniversityContactCreate(UniversityContactBase):
     pass
+
 
 class UniversityContactUpdate(BaseModel):
     university: Optional[str] = None
@@ -43,11 +49,13 @@ class UniversityContactUpdate(BaseModel):
     class Config(ConfigBase):
         pass
 
+
 class UniversityContactInDB(UniversityContactBase):
     id: int
 
     class Config(ConfigBase):
         pass
+
 
 class UniversityContactResponse(UniversityContactInDB):
     pass

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,3 +1,5 @@
+"""Schemas describing tasks and related operations."""
+
 from datetime import date, datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field
@@ -9,32 +11,40 @@ class ConfigBase:
     from_attributes = True
     populate_by_name = True
 
+
 class TaskBase(BaseModel):
     title: str
     description: Optional[str] = None
     status: TaskStatus = TaskStatus.TODO
     priority: TaskPriority = TaskPriority.MEDIUM
-    assigned_positions: List[str] = Field(default_factory=list, alias="assignedPositions")
+    assigned_positions: List[str] = Field(
+        default_factory=list, alias="assignedPositions"
+    )
     due_date: Optional[date] = Field(None, alias="dueDate")
     tags: List[str] = Field(default_factory=list)
 
     class Config(ConfigBase):
         pass
 
+
 class TaskCreate(TaskBase):
     created_by: str = Field(alias="createdBy")
+
 
 class TaskUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     status: Optional[TaskStatus] = None
     priority: Optional[TaskPriority] = None
-    assigned_positions: Optional[List[str]] = Field(default=None, alias="assignedPositions")
+    assigned_positions: Optional[List[str]] = Field(
+        default=None, alias="assignedPositions"
+    )
     due_date: Optional[date] = Field(default=None, alias="dueDate")
     tags: Optional[List[str]] = None
 
     class Config(ConfigBase):
         pass
+
 
 class TaskInDB(TaskBase):
     id: int
@@ -43,6 +53,7 @@ class TaskInDB(TaskBase):
 
     class Config(ConfigBase):
         pass
+
 
 class TaskResponse(TaskInDB):
     pass

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,6 +1,9 @@
+"""Pydantic models representing user data."""
+
 from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, EmailStr, Field
+
 
 class ConfigBase:
     from_attributes = True
@@ -17,8 +20,10 @@ class UserBase(BaseModel):
     class Config(ConfigBase):
         pass
 
+
 class UserCreate(UserBase):
     password: str
+
 
 class UserInDB(UserBase):
     id: int
@@ -27,6 +32,7 @@ class UserInDB(UserBase):
 
     class Config(ConfigBase):
         pass
+
 
 class UserResponse(UserBase):
     id: int

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -1,3 +1,5 @@
+"""Database initialization utilities used on application startup."""
+
 import os
 from sqlalchemy.future import select
 


### PR DESCRIPTION
## Summary
- document FastAPI backend modules
- ensure Python code formatted with `black`

## Testing
- `black backend/app/db.py backend/app/routers/auth.py backend/app/routers/contacts.py backend/app/routers/tasks.py backend/app/routers/users.py backend/app/routers/__init__.py backend/app/schemas/contact.py backend/app/schemas/task.py backend/app/schemas/user.py backend/app/schemas/__init__.py backend/app/startup.py`

------
https://chatgpt.com/codex/tasks/task_e_6843159811d8832bb9daf0197ae76cca