### PR TITLE
Update database SSL param handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ frontend.  During development you normally run them separately.
 2. **Environment variables** – copy the provided example and fill in the
    database connection and secret:
    ```bash
-   cp .env.sample .env
-   # edit .env and set DATABASE_URL and SECRET_KEY
-   ```
+cp .env.sample .env
+# edit .env and set DATABASE_URL and SECRET_KEY
+```
+   Make sure the `DATABASE_URL` includes `ssl=require` when connecting to a database that requires SSL.
 3. **Configure the chair account** – add a password to `.env`:
    ```bash
    echo "CHAIR_PASSWORD=my-secret" >> .env

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,5 +1,5 @@
 # Example Neon database URL
-DATABASE_URL=postgresql+asyncpg://user:password@host/dbname?sslmode=require
+DATABASE_URL=postgresql+asyncpg://user:password@host/dbname?ssl=require
 SECRET_KEY=super-secret-key
 # Initial chair account password
 CHAIR_PASSWORD=change-me

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -15,10 +15,13 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
     raise ValueError("DATABASE_URL not set")
 
-# Ensure Neon connections use SSL
-if "sslmode" not in DATABASE_URL:
+# Ensure Neon connections use SSL using the `ssl` parameter
+if "sslmode=require" in DATABASE_URL:
+    DATABASE_URL = DATABASE_URL.replace("sslmode=require", "ssl=require")
+
+if "ssl=" not in DATABASE_URL:
     suffix = "&" if "?" in DATABASE_URL else "?"
-    DATABASE_URL = f"{DATABASE_URL}{suffix}sslmode=require"
+    DATABASE_URL = f"{DATABASE_URL}{suffix}ssl=require"
 
 engine: AsyncEngine = create_async_engine(DATABASE_URL, echo=True)
 


### PR DESCRIPTION
## Summary
- update example `DATABASE_URL` to use `ssl` parameter
- enforce `ssl=require` in runtime configuration
- document that `DATABASE_URL` should include `ssl=require`

## Testing
- `black backend/app/db.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68431a061030832bbf5bb2157af98d0a